### PR TITLE
Add team dinner turn, dormitory id, and sopar info page

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { PanellAdminComponent } from './panell-admin/panell-admin.component'
 import { EditarEquipAuthComponent } from './editar-equip-auth/editar-equip-auth.component'
 import { InscripcionsTancadesComponent } from './inscripcions-tancades/inscripcions-tancades.component'
 import { QrCodeInfoComponent } from './qr-code-info/qr-code-info.component'
+import { SoparInfoComponent } from './sopar-info/sopar-info.component'
 
 export const routes: Routes = [
   { path: 'administrador-login', component: LoginComponent },
@@ -44,6 +45,7 @@ export const routes: Routes = [
     component: EditarEquipAuthComponent,
   },
   { path: 'menjars', component: QrCodeInfoComponent },
+  { path: 'sopar', component: SoparInfoComponent },
   { path: '**', redirectTo: '/pagina-principal', pathMatch: 'full' },
 ]
 

--- a/client/src/app/sopar-info/sopar-info.component.css
+++ b/client/src/app/sopar-info/sopar-info.component.css
@@ -1,0 +1,167 @@
+.page {
+  min-height: 100vh;
+  background: #1f1f1f;
+  color: #f5f5f5;
+  padding: 1.25rem;
+}
+
+.loading-container,
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 80vh;
+  text-align: center;
+  gap: 1rem;
+}
+
+.error-container h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--primary, #d36600);
+}
+
+.error-container p {
+  margin: 0;
+  opacity: 0.85;
+  max-width: 28rem;
+}
+
+.content {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.team-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: var(--primary, #d36600);
+  font-weight: 600;
+}
+
+.team-header h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.2rem);
+  color: #fff;
+}
+
+.team-header h2 {
+  margin: 0.35rem 0 0;
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+  color: var(--primary, #d36600);
+  font-weight: 500;
+}
+
+.meta {
+  margin: 0.75rem 0 0;
+  opacity: 0.75;
+}
+
+.highlight-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 600px) {
+  .highlight-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.highlight-card {
+  background: #333;
+  border-radius: 16px;
+  padding: 1.5rem;
+  text-align: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.highlight-card--primary {
+  border: 2px solid var(--primary, #d36600);
+}
+
+.label {
+  display: block;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 0.75rem;
+}
+
+.value {
+  margin: 0;
+  font-size: clamp(2.5rem, 10vw, 4rem);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--primary, #d36600);
+}
+
+.value--pending {
+  font-size: clamp(1rem, 3vw, 1.25rem);
+  font-weight: 500;
+  opacity: 0.7;
+}
+
+.members-section {
+  background: #333;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.members-section h3 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+  color: var(--primary, #d36600);
+  text-align: center;
+}
+
+.members-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (min-width: 480px) {
+  .members-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.member-card {
+  background: #444;
+  border-radius: 12px;
+  padding: 1.25rem 1rem;
+  text-align: center;
+}
+
+.member-card--total {
+  background: #2a2a2a;
+  border: 1px solid rgba(211, 102, 0, 0.35);
+}
+
+.member-count {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.1;
+}
+
+.member-label {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.75);
+}

--- a/client/src/app/sopar-info/sopar-info.component.html
+++ b/client/src/app/sopar-info/sopar-info.component.html
@@ -1,0 +1,61 @@
+<div class="page">
+  <div *ngIf="!teamInfo && !error" class="loading-container">
+    <mat-spinner diameter="40"></mat-spinner>
+    <p>Carregant informació del sopar...</p>
+  </div>
+
+  <div *ngIf="error" class="error-container">
+    <h1>No s'ha pogut carregar la informació</h1>
+    <p>Comprova que l'enllaç sigui correcte i que el token sigui vàlid.</p>
+  </div>
+
+  <div *ngIf="teamInfo" class="content">
+    <header class="team-header">
+      <p class="eyebrow">Sopar LUDIBÀSQUET</p>
+      <h1>{{ teamInfo.nomEquip }}</h1>
+      <h2>{{ teamInfo.club }}</h2>
+      <p class="meta">{{ teamInfo.categoria }} · {{ teamInfo.sexe }}</p>
+    </header>
+
+    <section class="highlight-grid">
+      <article class="highlight-card highlight-card--primary">
+        <span class="label">Torn de sopar</span>
+        <p class="value" *ngIf="teamInfo.tornSopar != null; else noTorn">
+          {{ teamInfo.tornSopar }}
+        </p>
+        <ng-template #noTorn>
+          <p class="value value--pending">Pendent d'assignar</p>
+        </ng-template>
+      </article>
+
+      <article class="highlight-card">
+        <span class="label">Dormitori</span>
+        <p class="value" *ngIf="teamInfo.idDormitori; else noDormitori">
+          {{ teamInfo.idDormitori }}
+        </p>
+        <ng-template #noDormitori>
+          <p class="value value--pending">Pendent d'assignar</p>
+        </ng-template>
+      </article>
+    </section>
+
+    <section class="members-section">
+      <h3>Comensals de l'equip</h3>
+      <div class="members-grid">
+        <article class="member-card">
+          <span class="member-count">{{ playersCount }}</span>
+          <span class="member-label">Jugadors</span>
+        </article>
+        <article class="member-card">
+          <span class="member-count">{{ coachesCount }}</span>
+          <span class="member-label">Entrenadors</span>
+        </article>
+        <article class="member-card member-card--total">
+          <span class="member-count">{{ totalMembers }}</span>
+          <span class="member-label">Total comensals</span>
+        </article>
+      </div>
+    </section>
+  </div>
+</div>
+

--- a/client/src/app/sopar-info/sopar-info.component.html
+++ b/client/src/app/sopar-info/sopar-info.component.html
@@ -20,22 +20,16 @@
     <section class="highlight-grid">
       <article class="highlight-card highlight-card--primary">
         <span class="label">Torn de sopar</span>
-        <p class="value" *ngIf="teamInfo.tornSopar != null; else noTorn">
-          {{ teamInfo.tornSopar }}
+        <p class="value" [class.value--pending]="tornSoparDisplay === '-'">
+          {{ tornSoparDisplay }}
         </p>
-        <ng-template #noTorn>
-          <p class="value value--pending">Pendent d'assignar</p>
-        </ng-template>
       </article>
 
       <article class="highlight-card">
         <span class="label">Dormitori</span>
-        <p class="value" *ngIf="teamInfo.idDormitori; else noDormitori">
-          {{ teamInfo.idDormitori }}
+        <p class="value" [class.value--pending]="dormitoriDisplay === '-'">
+          {{ dormitoriDisplay }}
         </p>
-        <ng-template #noDormitori>
-          <p class="value value--pending">Pendent d'assignar</p>
-        </ng-template>
       </article>
     </section>
 

--- a/client/src/app/sopar-info/sopar-info.component.ts
+++ b/client/src/app/sopar-info/sopar-info.component.ts
@@ -55,6 +55,26 @@ export class SoparInfoComponent implements OnInit {
     return this.playersCount + this.coachesCount
   }
 
+  get tornSoparDisplay(): string {
+    const torn = this.teamInfo?.tornSopar
+    if (torn == null) return '-'
+    switch (torn) {
+      case 1:
+        return '20:00'
+      case 2:
+        return '20:45'
+      case 3:
+        return '21:30'
+      default:
+        return '-'
+    }
+  }
+
+  get dormitoriDisplay(): string {
+    const dormitori = this.teamInfo?.idDormitori?.trim()
+    return dormitori ? dormitori : '-'
+  }
+
   private async fetchTeamInfo(token: string): Promise<void> {
     const url = `${environment.apiBaseUrl}/api/me/team`
     const headers = {

--- a/client/src/app/sopar-info/sopar-info.component.ts
+++ b/client/src/app/sopar-info/sopar-info.component.ts
@@ -1,0 +1,80 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { ActivatedRoute, Router } from '@angular/router'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { environment } from '../../environments/environment'
+import { take } from 'rxjs'
+
+interface SoparTeamInfo {
+  nomEquip: string
+  club: string
+  categoria: string
+  sexe: string
+  tornSopar?: number
+  idDormitori?: string
+  jugadors: unknown[]
+  entrenadors: unknown[]
+}
+
+@Component({
+  selector: 'app-sopar-info',
+  standalone: true,
+  imports: [CommonModule, MatProgressSpinnerModule],
+  templateUrl: './sopar-info.component.html',
+  styleUrl: './sopar-info.component.css',
+})
+export class SoparInfoComponent implements OnInit {
+  public teamInfo?: SoparTeamInfo
+  public error = false
+
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit() {
+    this.route.queryParams.pipe(take(1)).subscribe(params => {
+      const token = params['token']
+      if (token) {
+        this.fetchTeamInfo(token)
+      } else {
+        this.error = true
+      }
+    })
+  }
+
+  get playersCount(): number {
+    return this.teamInfo?.jugadors?.length ?? 0
+  }
+
+  get coachesCount(): number {
+    return this.teamInfo?.entrenadors?.length ?? 0
+  }
+
+  get totalMembers(): number {
+    return this.playersCount + this.coachesCount
+  }
+
+  private async fetchTeamInfo(token: string): Promise<void> {
+    const url = `${environment.apiBaseUrl}/api/me/team`
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+
+    try {
+      const response = await fetch(url, { method: 'GET', headers })
+
+      if (!response.ok) {
+        this.error = true
+        return
+      }
+
+      this.teamInfo = await response.json()
+    } catch (err) {
+      console.error('Error fetching dinner info:', err)
+      this.error = true
+    }
+  }
+}
+

--- a/server/go-server/database/migrations/000003_add_team_dinner_turn_restroom.down.sql
+++ b/server/go-server/database/migrations/000003_add_team_dinner_turn_restroom.down.sql
@@ -1,0 +1,16 @@
+DROP PROCEDURE IF EXISTS _migrate_000003_dinner_dormitory_down;
+DELIMITER //
+CREATE PROCEDURE _migrate_000003_dinner_dormitory_down()
+BEGIN
+  IF (SELECT COUNT(*) FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'teams' AND COLUMN_NAME = 'dormitory_id') > 0 THEN
+    ALTER TABLE teams DROP COLUMN dormitory_id;
+  END IF;
+  IF (SELECT COUNT(*) FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'teams' AND COLUMN_NAME = 'dinner_turn') > 0 THEN
+    ALTER TABLE teams DROP COLUMN dinner_turn;
+  END IF;
+END//
+DELIMITER ;
+CALL _migrate_000003_dinner_dormitory_down();
+DROP PROCEDURE IF EXISTS _migrate_000003_dinner_dormitory_down;

--- a/server/go-server/database/migrations/000003_add_team_dinner_turn_restroom.up.sql
+++ b/server/go-server/database/migrations/000003_add_team_dinner_turn_restroom.up.sql
@@ -1,0 +1,17 @@
+-- Add optional dinner turn and dormitory id for teams (idempotent).
+DROP PROCEDURE IF EXISTS _migrate_000003_dinner_dormitory;
+DELIMITER //
+CREATE PROCEDURE _migrate_000003_dinner_dormitory()
+BEGIN
+  IF (SELECT COUNT(*) FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'teams' AND COLUMN_NAME = 'dinner_turn') = 0 THEN
+    ALTER TABLE teams ADD COLUMN dinner_turn INT NULL AFTER observations;
+  END IF;
+  IF (SELECT COUNT(*) FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'teams' AND COLUMN_NAME = 'dormitory_id') = 0 THEN
+    ALTER TABLE teams ADD COLUMN dormitory_id VARCHAR(255) NULL AFTER dinner_turn;
+  END IF;
+END//
+DELIMITER ;
+CALL _migrate_000003_dinner_dormitory();
+DROP PROCEDURE IF EXISTS _migrate_000003_dinner_dormitory;

--- a/server/go-server/database/schema.sql
+++ b/server/go-server/database/schema.sql
@@ -24,6 +24,8 @@ CREATE TABLE teams (
     gender ENUM('Masculí', 'Femení') NOT NULL,
     club_id INT NOT NULL,
     observations TEXT,
+    dinner_turn INT NULL,
+    dormitory_id VARCHAR(255) NULL,
     registration_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     status ENUM('pending_payment', 'canceled', 'active') DEFAULT 'pending_payment',

--- a/server/go-server/internal/database/mysql/repositories/team_repository.go
+++ b/server/go-server/internal/database/mysql/repositories/team_repository.go
@@ -52,7 +52,7 @@ func (r *TeamRepository) CreateTeam(ctx context.Context, team *models.TeamCreate
 // GetTeamByID retrieves a team by ID
 func (r *TeamRepository) GetTeamByID(ctx context.Context, id int) (*models.Team, error) {
 	query := `
-		SELECT id, name, email, category, phone, gender, club_id, observations, registration_date, updated_at, status
+		SELECT id, name, email, category, phone, gender, club_id, observations, dinner_turn, dormitory_id, registration_date, updated_at, status
 		FROM teams
 		WHERE id = ?
 	`
@@ -67,6 +67,8 @@ func (r *TeamRepository) GetTeamByID(ctx context.Context, id int) (*models.Team,
 		&team.Gender,
 		&team.ClubID,
 		&team.Observations,
+		&team.DinnerTurn,
+		&team.DormitoryID,
 		&team.RegistrationDate,
 		&team.UpdatedAt,
 		&team.Status,
@@ -85,7 +87,7 @@ func (r *TeamRepository) GetTeamByID(ctx context.Context, id int) (*models.Team,
 // GetTeamByEmail retrieves a team by email
 func (r *TeamRepository) GetTeamByEmail(ctx context.Context, email string) (*models.Team, error) {
 	query := `
-		SELECT id, name, email, category, phone, gender, club_id, observations, registration_date, updated_at, status
+		SELECT id, name, email, category, phone, gender, club_id, observations, dinner_turn, dormitory_id, registration_date, updated_at, status
 		FROM teams
 		WHERE email = ?
 	`
@@ -100,6 +102,8 @@ func (r *TeamRepository) GetTeamByEmail(ctx context.Context, email string) (*mod
 		&team.Gender,
 		&team.ClubID,
 		&team.Observations,
+		&team.DinnerTurn,
+		&team.DormitoryID,
 		&team.RegistrationDate,
 		&team.UpdatedAt,
 		&team.Status,
@@ -119,7 +123,7 @@ func (r *TeamRepository) GetTeamByEmail(ctx context.Context, email string) (*mod
 func (r *TeamRepository) UpdateTeam(ctx context.Context, id int, team *models.TeamUpdateRequest) error {
 	query := `
 		UPDATE teams
-		SET name = ?, email = ?, category = ?, phone = ?, gender = ?, club_id = ?, observations = ?, status = ?, updated_at = NOW()
+		SET name = ?, email = ?, category = ?, phone = ?, gender = ?, club_id = ?, observations = ?, dinner_turn = ?, dormitory_id = ?, status = ?, updated_at = NOW()
 		WHERE id = ?
 	`
 
@@ -131,6 +135,8 @@ func (r *TeamRepository) UpdateTeam(ctx context.Context, id int, team *models.Te
 		team.Gender,
 		team.ClubID,
 		team.Observations,
+		team.DinnerTurn,
+		team.DormitoryID,
 		team.Status,
 		id,
 	)
@@ -193,7 +199,7 @@ func (r *TeamRepository) ListTeams(ctx context.Context, filters models.TeamFilte
 	// Subquery: one valid registration token per team (latest by created_at)
 	tokenSubq := `(SELECT rt.token FROM registration_tokens rt WHERE rt.team_id = teams.id AND rt.expires_at > UTC_TIMESTAMP() ORDER BY rt.created_at DESC LIMIT 1)`
 	// Build the query with filters
-	query := `SELECT teams.id, teams.name, teams.email, teams.category, teams.phone, teams.gender, teams.club_id, teams.observations, teams.registration_date, teams.updated_at, teams.status, ` + tokenSubq + ` AS registration_token FROM teams`
+	query := `SELECT teams.id, teams.name, teams.email, teams.category, teams.phone, teams.gender, teams.club_id, teams.observations, teams.dinner_turn, teams.dormitory_id, teams.registration_date, teams.updated_at, teams.status, ` + tokenSubq + ` AS registration_token FROM teams`
 	args := []interface{}{}
 
 	var conditions []string
@@ -262,6 +268,8 @@ func (r *TeamRepository) ListTeams(ctx context.Context, filters models.TeamFilte
 			&team.Gender,
 			&team.ClubID,
 			&team.Observations,
+			&team.DinnerTurn,
+			&team.DormitoryID,
 			&team.RegistrationDate,
 			&team.UpdatedAt,
 			&team.Status,
@@ -280,6 +288,8 @@ func (r *TeamRepository) ListTeams(ctx context.Context, filters models.TeamFilte
 			Gender:            team.Gender,
 			ClubID:            team.ClubID,
 			Observations:      team.Observations,
+			DinnerTurn:        team.DinnerTurn,
+			DormitoryID:        team.DormitoryID,
 			RegistrationDate:  team.RegistrationDate,
 			UpdatedAt:         team.UpdatedAt,
 			Status:            team.Status,

--- a/server/go-server/internal/handlers/team_handler.go
+++ b/server/go-server/internal/handlers/team_handler.go
@@ -242,6 +242,8 @@ func (h *TeamHandler) GetMeTeam(w http.ResponseWriter, r *http.Request) {
 		Intolerancies:  intolerancies,
 		Jugadors:       make([]models.MeTeamJugador, 0, len(team.Players)),
 		Entrenadors:    make([]models.MeTeamEntrenador, 0, len(team.Coaches)),
+		TornSopar:      team.DinnerTurn,
+		IdDormitori:    team.DormitoryID,
 	}
 	for _, p := range team.Players {
 		resp.Jugadors = append(resp.Jugadors, models.MeTeamJugador{

--- a/server/go-server/internal/models/team.go
+++ b/server/go-server/internal/models/team.go
@@ -16,6 +16,8 @@ type Team struct {
 	ID int `json:"id" db:"id"`
 	TeamBase
 	Observations     *string   `json:"observations" db:"observations"`
+	DinnerTurn       *int      `json:"dinner_turn,omitempty" db:"dinner_turn"`
+	DormitoryID      *string   `json:"dormitory_id,omitempty" db:"dormitory_id"`
 	RegistrationDate time.Time `json:"registration_date" db:"registration_date"`
 	UpdatedAt        time.Time `json:"updated_at" db:"updated_at"`
 
@@ -32,6 +34,8 @@ type TeamCreateRequest struct {
 type TeamUpdateRequest struct {
 	TeamBase
 	Observations *string `json:"observations,omitempty"`
+	DinnerTurn   *int    `json:"dinner_turn,omitempty"`
+	DormitoryID  *string `json:"dormitory_id,omitempty"`
 }
 
 type TeamResponse struct {
@@ -43,6 +47,8 @@ type TeamResponse struct {
 	Gender             Gender        `json:"gender"`
 	ClubID             int           `json:"club_id"`
 	Observations       *string       `json:"observations"`
+	DinnerTurn         *int          `json:"dinner_turn,omitempty"`
+	DormitoryID        *string       `json:"dormitory_id,omitempty"`
 	RegistrationDate   time.Time     `json:"registration_date"`
 	UpdatedAt          time.Time     `json:"updated_at"`
 	Status             Status        `json:"status"`
@@ -91,6 +97,8 @@ type MeTeamResponse struct {
 	Jugadors          []MeTeamJugador    `json:"jugadors"`
 	Entrenadors       []MeTeamEntrenador `json:"entrenadors"`
 	RegistrationToken *string            `json:"registrationToken,omitempty"`
+	TornSopar         *int               `json:"tornSopar,omitempty"`
+	IdDormitori       *string            `json:"idDormitori,omitempty"`
 }
 
 type MeTeamUpdateRequest struct {


### PR DESCRIPTION
## Summary
- Add optional `dinner_turn` and `dormitory_id` columns on teams (migration 000003).
- Expose `tornSopar` and `idDormitori` on `GET /api/me/team` for team token access.
- Add a new client route `/sopar?token=...` that shows dinner turn, dormitory, and player/coach counts in a mobile-friendly layout.

## Test plan
- [x] Migration applied on test DB (`000003`)
- [x] Test API deployed (`pepalonso/ludi-server:0.3.0`)
- [ ] Set `dinner_turn` and `dormitory_id` for a test team via admin API/SQL
- [ ] Open `/sopar?token=<registration_token>` and verify torn, dormitori, jugadors, and entrenadors counts
- [ ] Confirm `/api/me/team` returns `tornSopar` and `idDormitori` when set


Made with [Cursor](https://cursor.com)