### PR TITLE
Add partits link button on sopar page

### DIFF
--- a/client/src/app/sopar-info/sopar-info.component.css
+++ b/client/src/app/sopar-info/sopar-info.component.css
@@ -113,6 +113,38 @@
   opacity: 0.7;
 }
 
+.partits-section {
+  margin-bottom: 1.5rem;
+}
+
+.partits-button {
+  display: block;
+  width: 100%;
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  background: var(--primary, #d36600);
+  color: #fff;
+  font-size: clamp(1.05rem, 3.5vw, 1.25rem);
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none;
+  box-shadow: 0 4px 14px rgba(211, 102, 0, 0.35);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    background 0.15s ease;
+}
+
+.partits-button:hover {
+  background: #e57710;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(211, 102, 0, 0.45);
+}
+
+.partits-button:active {
+  transform: translateY(0);
+}
+
 .members-section {
   background: #333;
   border-radius: 16px;
@@ -165,3 +197,4 @@
   font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.75);
 }
+

--- a/client/src/app/sopar-info/sopar-info.component.html
+++ b/client/src/app/sopar-info/sopar-info.component.html
@@ -33,6 +33,12 @@
       </article>
     </section>
 
+    <section *ngIf="partitsUrl" class="partits-section">
+      <a class="partits-button" [href]="partitsUrl" target="_blank" rel="noopener noreferrer">
+        Fes clic per veure els partits
+      </a>
+    </section>
+
     <section class="members-section">
       <h3>Comensals de l'equip</h3>
       <div class="members-grid">

--- a/client/src/app/sopar-info/sopar-info.component.ts
+++ b/client/src/app/sopar-info/sopar-info.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router'
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 import { environment } from '../../environments/environment'
 import { take } from 'rxjs'
+import { getPartitsUrl } from './sopar-partits-links'
 
 interface SoparTeamInfo {
   nomEquip: string
@@ -73,6 +74,11 @@ export class SoparInfoComponent implements OnInit {
   get dormitoriDisplay(): string {
     const dormitori = this.teamInfo?.idDormitori?.trim()
     return dormitori ? dormitori : '-'
+  }
+
+  get partitsUrl(): string | undefined {
+    if (!this.teamInfo) return undefined
+    return getPartitsUrl(this.teamInfo.categoria, this.teamInfo.sexe)
   }
 
   private async fetchTeamInfo(token: string): Promise<void> {

--- a/client/src/app/sopar-info/sopar-partits-links.ts
+++ b/client/src/app/sopar-info/sopar-partits-links.ts
@@ -1,0 +1,34 @@
+import { Categories, Sexe } from '../interfaces/ludi.interface'
+
+/** DB category + gender → Xporty partits URL (from temp/links categories CSV). */
+const partitsLinks: Record<string, string> = {
+  // Pre-mini: single bracket for both genders in the tournament
+  [`${Categories.PREMINI}|${Sexe.MASC}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276362',
+  [`${Categories.PREMINI}|${Sexe.FEM}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276362',
+  [`${Categories.MINI}|${Sexe.FEM}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276363',
+  [`${Categories.MINI}|${Sexe.MASC}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276364',
+  [`${Categories.PREINFANTIL}|${Sexe.MASC}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276369',
+  [`${Categories.PREINFANTIL}|${Sexe.FEM}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276370',
+  [`${Categories.INFANTIL}|${Sexe.FEM}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276372',
+  [`${Categories.INFANTIL}|${Sexe.MASC}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276373',
+  [`${Categories.CADET}|${Sexe.FEM}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276376',
+  [`${Categories.CADET}|${Sexe.MASC}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276380',
+  [`${Categories.JUNIOR}|${Sexe.FEM}`]:
+    'https://www.xporty.com/tournaments/9276275-24e-ludibasquet/participants?e_id=9276384',
+}
+
+export function getPartitsUrl(categoria: string, sexe: string): string | undefined {
+  const url = partitsLinks[`${categoria}|${sexe}`]
+  return url?.trim() || undefined
+}
+


### PR DESCRIPTION
## Summary
- Add a prominent **Fes clic per veure els partits** button on `/sopar`.
- Show the button when a URL exists for the team's `categoria` + `sexe` (DB values).
- Map category/gender pairs to Xporty bracket links; opens in a new tab.

## Test plan
- [ ] Open `/sopar?token=...` for a Cadet Femení team → button visible, opens correct Xporty page
- [ ] Open for Pre-mini (both genders share same bracket link)
- [ ] Confirm Júnior Masculí teams do not show the button (no URL in mapping yet)


Made with [Cursor](https://cursor.com)